### PR TITLE
Make implementation behave more like NodeJS net socket API

### DIFF
--- a/TcpSocket.js
+++ b/TcpSocket.js
@@ -389,7 +389,13 @@ TcpSocket.prototype._write = function(
   if (this._state === STATE.DISCONNECTED) {
     throw new Error('Socket is not connected.');
   } else if (this._state === STATE.CONNECTING) {
-    // we're ok, GCDAsyncSocket handles queueing internally
+    // If we are still connecting, then buffer this for later.
+    // The Writable logic will buffer up any more writes while
+    // waiting for this one to be done.
+    this.once('connect', function connect() {
+      this._write(buffer, encoding, callback);
+    });
+    return
   }
 
   callback = callback || noop;

--- a/TcpSocket.js
+++ b/TcpSocket.js
@@ -118,6 +118,8 @@ TcpSocket.prototype.connect = function(options, callback): TcpSocket {
     this._activeTimer(this._timeout.msecs);
   }
 
+  this._undestroy()
+
   this._state = STATE.CONNECTING;
   this.writable = true
   this._destroyed = false;

--- a/TcpSocket.js
+++ b/TcpSocket.js
@@ -119,6 +119,7 @@ TcpSocket.prototype.connect = function(options, callback): TcpSocket {
   }
 
   this._state = STATE.CONNECTING;
+  this.writable = true
   this._destroyed = false;
 
   if (path) {
@@ -249,6 +250,7 @@ TcpSocket.prototype.end = function(data, encoding) {
 TcpSocket.prototype.destroy = function() {
   if (!this._destroyed) {
     this._destroyed = true;
+    this.writable = false;
     this._debug('destroying');
     this._clearTimeout();
 
@@ -442,6 +444,7 @@ function setDisconnected(socket: TcpSocket, hadError: boolean): void {
 
   socket._unregisterEvents();
   socket._state = STATE.DISCONNECTED;
+  socket.writable = false;
   socket.emit('close', hadError);
 }
 

--- a/TcpSocket.js
+++ b/TcpSocket.js
@@ -65,7 +65,7 @@ util.inherits(TcpSocket, stream.Duplex);
 TcpSocket.prototype._debug = function() {
   if (__DEV__) {
     var args = [].slice.call(arguments);
-    args.unshift('socket-' + this._id);
+    args.unshift('RNTcpSocket-' + this._id);
     console.log.apply(console, args);
   }
 };


### PR DESCRIPTION
This PR fixes issues observed in https://github.com/celo-org/celo-monorepo/issues/1422

The main problem was `react-native-tcp` behaved slightly differently from the NodeJS net socket implementation and resulted in the initial write to the socket being lost while connecting on Android and failing on iOS.

- Fix unable to write while connecting on Android. NodeJS net socket allows writing while connecting. See https://github.com/nodejs/node/blob/96a65e85c59ab4a81f49f7088d9f4d270980c5b0/lib/net.js#L754-L764 Though iOS native implementation already supported write while connecting, it's now doing the logic in JS so it behaves the same and matches NodeJS implementation.
- Add writable property to support web3 rpc provider use case. See https://github.com/ethereum/web3.js/blob/4d57461fe8e9d26662d5a5afc9c03f38fb7a28be/packages/web3-providers-ipc/src/index.js#L208-L210
- Call undestroy on connect so closed or ended socket can be reused.
This matches NodeJS implementation https://github.com/nodejs/node/blob/96a65e85c59ab4a81f49f7088d9f4d270980c5b0/lib/net.js#L233
- Make the origin of 'socket-X' log messages clearer

I'm sure there are other edge cases, but it currently works as expected for our usage.