### PR TITLE
fix for "More than one file was found with OS independent path

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,6 +34,10 @@ android {
         abortOnError false
         warning 'InvalidPackage'
     }
+    
+    packagingOptions {
+        pickFirst '**/libc++_shared.so'
+    }
 }
 
 repositories {


### PR DESCRIPTION
Fix for this error which occurs when trying to build in test mode:

> Task :react-native-tcp:transformNativeLibsWithMergeJniLibsForDebugAndroidTest FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':react-native-tcp:transformNativeLibsWithMergeJniLibsForDebugAndroidTest'.
> More than one file was found with OS independent path 'lib/x86/libc++_shared.so'
